### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(2) do |config|
                             autoconf automake libtool gcc g++ gperf \
                             flex bison texinfo gawk ncurses-dev libexpat-dev \
                             python sed libreadline-dev libffi-dev pkg-config \
-                            help2man python-dev python-serial wget linux-image-extra-$(uname -r)
+                            help2man python-dev python-serial wget linux-modules-extra-$(uname -r)
     echo "Installing Espressif ESP32 toolchain..."
     cd ~
     wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz 2> /dev/null


### PR DESCRIPTION
"sudo apt-get install linux-image-extra-$(uname -r)" was throwing errors. Turns out that:
linux-image-extra-*
packages have been renamed
linux-modules-extra-*